### PR TITLE
Used addItem with a valueDefault to ensure items exist

### DIFF
--- a/src/StateHoldr.ts
+++ b/src/StateHoldr.ts
@@ -177,7 +177,9 @@ export class StateHoldr implements IStateHoldr {
         this.itemsHolder.setItem(`${this.prefix}${collectionKeysItemName}`, this.collectionKeys);
 
         if (!this.itemsHolder.hasKey(`${this.prefix}${collectionKey}`)) {
-            this.itemsHolder.setItem(`${this.prefix}${collectionKey}`, {});
+            this.itemsHolder.addItem(`${this.prefix}${collectionKey}`, {
+                valueDefault: {},
+            });
         }
     }
 


### PR DESCRIPTION
This way, if the item would have its value set by storage, it won't be overridden by StateHoldr accidentally.

Fixes #33.